### PR TITLE
Add two simple services to process topological-inventory payloads from the upload service

### DIFF
--- a/bin/topological-inventory-inventory-upload
+++ b/bin/topological-inventory-inventory-upload
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+
+lib = File.expand_path("../lib", __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+STDOUT.sync = true
+
+require "bundler/setup"
+require "topological_inventory/sync/inventory_upload_worker"
+
+def parse_args
+  require 'optimist'
+  opts = Optimist.options do
+    opt :queue_host, "Hostname of the Platform's kafka queue", :type => :string,
+        :default => ENV["QUEUE_HOST"] || "localhost"
+    opt :queue_port, "Port of the Platform's kafka queue", :type => :int,
+        :default => (ENV["QUEUE_PORT"] || 9092).to_i, :required => false
+  end
+
+  opts
+end
+
+args = parse_args
+
+topological_inventory_sync = TopologicalInventory::Sync::InventoryUploadWorker.new(args[:queue_host], args[:queue_port])
+topological_inventory_sync.run

--- a/bin/topological-inventory-inventory-upload
+++ b/bin/topological-inventory-inventory-upload
@@ -12,9 +12,9 @@ def parse_args
   require 'optimist'
   opts = Optimist.options do
     opt :queue_host, "Hostname of the Platform's kafka queue", :type => :string,
-        :default => ENV["QUEUE_HOST"] || "localhost"
+        :default => ENV.fetch("QUEUE_HOST", "localhost")
     opt :queue_port, "Port of the Platform's kafka queue", :type => :int,
-        :default => (ENV["QUEUE_PORT"] || 9092).to_i, :required => false
+        :default => (ENV.fetch("QUEUE_PORT", 9092)).to_i, :required => false
   end
 
   opts

--- a/bin/topological-inventory-inventory-upload-validator
+++ b/bin/topological-inventory-inventory-upload-validator
@@ -12,9 +12,9 @@ def parse_args
   require 'optimist'
   opts = Optimist.options do
     opt :queue_host, "Hostname of the Platform's kafka queue", :type => :string,
-        :default => ENV["QUEUE_HOST"] || "localhost"
+        :default => ENV.fetch("QUEUE_HOST", "localhost")
     opt :queue_port, "Port of the Platform's kafka queue", :type => :int,
-        :default => (ENV["QUEUE_PORT"] || 9092).to_i, :required => false
+        :default => (ENV.fetch("QUEUE_PORT", 9092)).to_i, :required => false
   end
 
   opts

--- a/bin/topological-inventory-inventory-upload-validator
+++ b/bin/topological-inventory-inventory-upload-validator
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+
+lib = File.expand_path("../lib", __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+STDOUT.sync = true
+
+require "bundler/setup"
+require "topological_inventory/sync/inventory_upload_validator_worker"
+
+def parse_args
+  require 'optimist'
+  opts = Optimist.options do
+    opt :queue_host, "Hostname of the Platform's kafka queue", :type => :string,
+        :default => ENV["QUEUE_HOST"] || "localhost"
+    opt :queue_port, "Port of the Platform's kafka queue", :type => :int,
+        :default => (ENV["QUEUE_PORT"] || 9092).to_i, :required => false
+  end
+
+  opts
+end
+
+args = parse_args
+
+topological_inventory_sync = TopologicalInventory::Sync::InventoryUploadValidatorWorker.new(args[:queue_host], args[:queue_port])
+topological_inventory_sync.run

--- a/lib/topological_inventory/sync/inventory_upload_validator_worker.rb
+++ b/lib/topological_inventory/sync/inventory_upload_validator_worker.rb
@@ -1,0 +1,33 @@
+require "json"
+require "topological_inventory/sync/worker"
+
+module TopologicalInventory
+  class Sync
+    class InventoryUploadValidatorWorker < Worker
+      include Logging
+
+      def queue_name
+        "platform.upload.topological-inventory"
+      end
+
+      def persist_ref
+        "topological-inventory-upload-validator"
+      end
+
+      def perform(message)
+        jobtype = message.message
+        payload = JSON.parse(message.payload)
+
+        logger.info("#{jobtype}: #{payload}")
+
+        payload["validation"] = "success"
+
+        messaging_client.publish_topic(
+          :service => "platform.upload.validation",
+          :event   => "", # TODO we shouldn't require this in MIQ-Messaging
+          :payload => payload.to_json
+        )
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/sync/inventory_upload_validator_worker.rb
+++ b/lib/topological_inventory/sync/inventory_upload_validator_worker.rb
@@ -15,18 +15,26 @@ module TopologicalInventory
       end
 
       def perform(message)
-        jobtype = message.message
         payload = JSON.parse(message.payload)
 
-        logger.info("#{jobtype}: #{payload}")
+        logger.info("#{payload}")
 
-        payload["validation"] = "success"
+        validation = valid_payload?(payload) ? "success" : "failure"
+
+        payload["validation"] = validation
 
         messaging_client.publish_topic(
           :service => "platform.upload.validation",
           :event   => "", # TODO we shouldn't require this in MIQ-Messaging
           :payload => payload.to_json
         )
+      end
+
+      private
+
+      def valid_payload?(_payload)
+        # TODO validate that this is a correct topological inventory payload
+        true
       end
     end
   end

--- a/lib/topological_inventory/sync/inventory_upload_worker.rb
+++ b/lib/topological_inventory/sync/inventory_upload_worker.rb
@@ -1,0 +1,25 @@
+require "json"
+require "topological_inventory/sync/worker"
+
+module TopologicalInventory
+  class Sync
+    class InventoryUploadWorker < Worker
+      include Logging
+
+      def queue_name
+        "platform.upload.available"
+      end
+
+      def persist_ref
+        "topological-inventory-upload-processor"
+      end
+
+      def perform(message)
+        payload = JSON.parse(message.payload)
+        return unless payload["service"] == "topological-inventory"
+
+        logger.info("#{payload}")
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/sync/worker.rb
+++ b/lib/topological_inventory/sync/worker.rb
@@ -7,8 +7,9 @@ module TopologicalInventory
       include Logging
 
       def initialize(messaging_host, messaging_port)
-        self.messaging_host = messaging_host
-        self.messaging_port = messaging_port
+        self.messaging_client = nil
+        self.messaging_host   = messaging_host
+        self.messaging_port   = messaging_port
       end
 
       def run
@@ -16,7 +17,7 @@ module TopologicalInventory
 
         initial_sync
 
-        messaging_client = ManageIQ::Messaging::Client.open(messaging_client_opts)
+        self.messaging_client = ManageIQ::Messaging::Client.open(messaging_client_opts)
         messaging_client.subscribe_topic(subscribe_opts) { |message| perform(message) }
       ensure
         messaging_client&.close
@@ -24,7 +25,7 @@ module TopologicalInventory
 
       private
 
-      attr_accessor :messaging_host, :messaging_port, :queue_name
+      attr_accessor :messaging_client, :messaging_host, :messaging_port, :queue_name
 
       def initial_sync
         # Override this in your subclass if there is any sync needed to be done


### PR DESCRIPTION
This adds a simple validation service and a processing service to handle topological-inventory and/or cfme payloads sent to the upload service.