### PR TITLE
Payload validation against Schema class

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "optimist"
 
 gem "sources-api-client",         :git => "https://github.com/ManageIQ/sources-api-client-ruby", :branch => "master"
 gem "topological_inventory-core", :git => "https://github.com/ManageIQ/topological_inventory-core", :branch => "master"
+gem "inventory_refresh",          :git => "https://github.com/ManageIQ/inventory_refresh", :branch => "master"
 
 group :development, :test do
   gem "rake"

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem "optimist"
 
 gem "sources-api-client",         :git => "https://github.com/ManageIQ/sources-api-client-ruby", :branch => "master"
 gem "topological_inventory-core", :git => "https://github.com/ManageIQ/topological_inventory-core", :branch => "master"
-gem "inventory_refresh",          :git => "https://github.com/ManageIQ/inventory_refresh", :branch => "master"
 
 group :development, :test do
   gem "rake"

--- a/bin/topological-inventory-inventory-upload-validator
+++ b/bin/topological-inventory-inventory-upload-validator
@@ -7,6 +7,7 @@ STDOUT.sync = true
 
 require "bundler/setup"
 require "topological_inventory/sync/inventory_upload_validator_worker"
+require "topological_inventory/schema"
 
 def parse_args
   require 'optimist'

--- a/lib/topological_inventory/sync/inventory_upload_validator_worker.rb
+++ b/lib/topological_inventory/sync/inventory_upload_validator_worker.rb
@@ -32,9 +32,15 @@ module TopologicalInventory
 
       private
 
-      def valid_payload?(_payload)
-        # TODO validate that this is a correct topological inventory payload
-        true
+      def valid_payload?(payload)
+        schema_name = payload.dig("metadata", "schema", "name")
+        schema_klass = schema_klass_name(schema_name).safe_constantize
+
+        schema_klass.present?
+      end
+
+      def schema_klass_name(name)
+        "TopologicalInventory::Schema::#{name}"
       end
     end
   end


### PR DESCRIPTION
Payload from InsightsUpload service has to be validated first. 
I'm using request metadata to check if schema class exists (using the same approach as `Persister::Worker`).

---

- [x] **depends on**: #3 

---

**On localhost:**
Sample payload:
```
plain_rh_identity="{\"identity\":{\"account_number\":\"test-mock\"}, \"internal\": {\"org_id\": \"54321\"}}"
export X_RH_IDENTITY=$(echo ${plain_rh_identity} | base64 --wrap=0)
curl -vvvv -H "x-rh-identity: ${X_RH_IDENTITY}" -F "upload=@README.md;type=application/vnd.redhat.topological-inventory.mock" -F metadata="{\"schema\": {\"name\": \"Default\"}}" -H "x-rh-insights-request-id: 123" localhost:8888/api/ingress/v1/upload
```
_Note: substitute @README.md with existing file_

Running insights-upload with params:
`INVENTORY_URL="http://localhost:8888/api/hosts" KAFKAMQ=localhost:9092 TOPIC_CONFIG="/home/mslemr/Projects/topics.json" python app.py`

Topics.json file:
```
[
   { 
	   "TOPIC_NAME": "advisor",
	   "PARTITIONS": 2,
	   "REPLICAS": 1
   },
   { 
	   "TOPIC_NAME": "validation",
	   "PARTITIONS": 2,
	   "REPLICAS": 1
   },
   { 
	   "TOPIC_NAME": "testareno",
	   "PARTITIONS": 2,
	   "REPLICAS": 1
   },
   {
	   "TOPIC_NAME": "hccm",
	   "PARTITIONS": 2,
	   "REPLICAS": 1
   },
   {
	   "TOPIC_NAME": "compliance",
	   "PARTITIONS": 2,
	   "REPLICAS": 1
   },
   { 
	   "TOPIC_NAME": "qpc",
	   "PARTITIONS": 2,
	   "REPLICAS": 1
   },
   { 
	   "TOPIC_NAME": "topological-inventory",
	   "PARTITIONS": 2,
	   "REPLICAS": 1
   }
]
```
