### PR TITLE
Fix the handling of ingress_api env vars

### DIFF
--- a/bin/topological-inventory-inventory-upload
+++ b/bin/topological-inventory-inventory-upload
@@ -15,8 +15,10 @@ def parse_args
         :default => ENV.fetch("QUEUE_HOST", "localhost")
     opt :queue_port, "Port of the Platform's kafka queue", :type => :int,
         :default => (ENV.fetch("QUEUE_PORT", 9092)).to_i, :required => false
-    opt :ingress_api, "Hostname of the ingress-api route", :type => :string,
-        :default => ENV.fetch("INGRESS_API", "http://localhost:9292")
+    opt :ingress_api_host, "Ingress API service URL", :type => :string,
+        :default => ENV["TOPOLOGICAL_INVENTORY_INGRESS_API_SERVICE_HOST"] || "localhost"
+    opt :ingress_api_port, "Ingress API service URL port", :type => :int,
+        :default => (ENV["TOPOLOGICAL_INVENTORY_INGRESS_API_SERVICE_PORT"] || 9292).to_i
   end
 
   opts
@@ -32,10 +34,11 @@ SourcesApiClient.configure do |config|
 end
 
 require "topological_inventory-ingress_api-client"
-ingress_api_uri = URI(args[:ingress_api])
-
-TopologicalInventoryIngressApiClient.configure.scheme = ingress_api_uri.scheme || "http"
-TopologicalInventoryIngressApiClient.configure.host   = "#{ingress_api_uri.host}:#{ingress_api_uri.port}"
+TopologicalInventoryIngressApiClient.configure do |config|
+  config.scheme = "http"
+  config.host   = "#{args[:ingress_api_host]}:#{args[:ingress_api_port]}"
+  config.logger = TopologicalInventory::Sync.logger
+end
 
 topological_inventory_sync = TopologicalInventory::Sync::InventoryUpload::ProcessorWorker.new(args[:queue_host], args[:queue_port])
 topological_inventory_sync.run


### PR DESCRIPTION
Allow building the ingress-api url from default env vars provided to the
service.