### PR TITLE
Allow for multiple files per payload

### DIFF
--- a/lib/topological_inventory/sync/inventory_upload/parser.rb
+++ b/lib/topological_inventory/sync/inventory_upload/parser.rb
@@ -4,16 +4,12 @@ module TopologicalInventory
       class Parser
         class << self
           def parse_inventory_payload(url)
-            inventory = nil
-
             open_url(url) do |io|
               untargz(io) do |file|
                 require "json/stream"
-                inventory = JSON::Stream::Parser.parse(file)
+                yield JSON::Stream::Parser.parse(file)
               end
             end
-
-            inventory
           end
 
           private

--- a/lib/topological_inventory/sync/inventory_upload/processor_worker.rb
+++ b/lib/topological_inventory/sync/inventory_upload/processor_worker.rb
@@ -31,9 +31,9 @@ module TopologicalInventory
 
           logger.info("#{log_header}: Processing payload [#{payload_id}]...")
 
-          inventory = TopologicalInventory::Sync::InventoryUpload::Parser.parse_inventory_payload(payload['url'])
-
-          process_inventory(inventory, account)
+          Parser.parse_inventory_payload(payload['url']) do |inventory|
+            process_inventory(inventory, account)
+          end
         end
 
         private

--- a/lib/topological_inventory/sync/inventory_upload/validator_worker.rb
+++ b/lib/topological_inventory/sync/inventory_upload/validator_worker.rb
@@ -28,8 +28,13 @@ module TopologicalInventory
 
           logger.info("#{log_header}: Validating payload [#{payload_id}]...")
 
-          inventory = Parser.parse_inventory_payload(payload["url"])
-          payload["validation"] = valid_payload?(inventory) ? "success" : "failure"
+          valid = "success"
+          Parser.parse_inventory_payload(payload["url"]) do |inventory|
+            # Return invalid if any of the payloads are invalid
+            valid = "failure" unless valid_payload?(inventory)
+          end
+
+          payload["validation"] = valid
 
           logger.info("#{log_header}: Validating payload [#{payload_id}]...Complete - #{payload["validation"]}")
 


### PR DESCRIPTION
Yield each inventory in a tgz file to allow for support of multiple json
files per tgz payload.