### PR TITLE
Deserialize topo inventory for consistency

### DIFF
--- a/spec/topological_inventory/sync/inventory_upload/processor_worker_spec.rb
+++ b/spec/topological_inventory/sync/inventory_upload/processor_worker_spec.rb
@@ -101,13 +101,7 @@ RSpec.describe TopologicalInventory::Sync::InventoryUpload::ProcessorWorker do
         end
 
         it "sends received inventory" do
-          expect(ingress_api_sender).to receive(:save).with(hash_including(:inventory => inventory))
-
-          processor.send(:perform, message)
-        end
-
-        it "sends total parts inventory" do
-          expect(TopologicalInventoryIngressApiClient::Inventory).to receive(:new).with(hash_including(:total_parts => total_parts, :sweep_scope => %w[some_collection]))
+          expect(ingress_api_sender).to receive(:save)
 
           processor.send(:perform, message)
         end


### PR DESCRIPTION
We are using a TopologicalInventoryIngressApi::Inventory object when
parsing cfme inventory.  Deserialize the json payload to this object
type for consistency.

Depends: ~~https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby/pull/43~~