### PR TITLE
Don't use ManageIQ::API::Common without Rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem "manageiq-loggers", "~> 0.3.0"
 gem "manageiq-messaging"
 gem "optimist"
 
-gem "manageiq-api-common",        :git => "https://github.com/ManageIQ/manageiq-api-common", :branch => "master"
 gem "sources-api-client",         :git => "https://github.com/ManageIQ/sources-api-client-ruby", :branch => "master"
 gem "topological_inventory-ingress_api-client", :git => "https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby", :branch => "master"
 gem "topological_inventory-core", :git => "https://github.com/ManageIQ/topological_inventory-core", :branch => "master"

--- a/lib/topological_inventory/sync/sources_sync_worker.rb
+++ b/lib/topological_inventory/sync/sources_sync_worker.rb
@@ -1,6 +1,5 @@
 require "rest-client"
 require "topological_inventory/sync/worker"
-require "manageiq-api-common"
 require "uri"
 
 module TopologicalInventory
@@ -95,7 +94,7 @@ module TopologicalInventory
       end
 
       def headers_to_account_number(headers)
-        ManageIQ::API::Common::Request.new(:headers => headers, :original_url => nil).identity.dig("identity", "account_number")
+        JSON.parse(Base64.decode64(headers["x-rh-identity"])).dig("identity", "account_number")
       end
     end
   end


### PR DESCRIPTION
The ManageIQ::API::Common gem has an engine that depends on rails, this
is not a rails app so just decode the headers manually.

```

== Writing encryption key ==
--
  | == Checking topological-inventory-postgresql:5432 status ==
  | topological-inventory-postgresql:5432 - accepting connections
  | /usr/local/lib/ruby/gems/2.4.0/bundler/gems/manageiq-api-common-dac4157d50ff/lib/manageiq/api/common/engine.rb:4:in `<module:Common>': uninitialized constant Rails (NameError)
  | from /usr/local/lib/ruby/gems/2.4.0/bundler/gems/manageiq-api-common-dac4157d50ff/lib/manageiq/api/common/engine.rb:3:in `<module:API>'
  | from /usr/local/lib/ruby/gems/2.4.0/bundler/gems/manageiq-api-common-dac4157d50ff/lib/manageiq/api/common/engine.rb:2:in `<module:ManageIQ>'
  | from /usr/local/lib/ruby/gems/2.4.0/bundler/gems/manageiq-api-common-dac4157d50ff/lib/manageiq/api/common/engine.rb:1:in `<top (required)>'
  | from /usr/local/lib/ruby/gems/2.4.0/bundler/gems/manageiq-api-common-dac4157d50ff/lib/manageiq/api/common.rb:1:in `require'
  | from /usr/local/lib/ruby/gems/2.4.0/bundler/gems/manageiq-api-common-dac4157d50ff/lib/manageiq/api/common.rb:1:in `<top (required)>'
  | from /usr/local/lib/ruby/gems/2.4.0/bundler/gems/manageiq-api-common-dac4157d50ff/lib/manageiq-api-common.rb:1:in `require'
  | from /usr/local/lib/ruby/gems/2.4.0/bundler/gems/manageiq-api-common-dac4157d50ff/lib/manageiq-api-common.rb:1:in `<top (required)>'
  | from /opt/topological_inventory-sync/lib/topological_inventory/sync/sources_sync_worker.rb:3:in `require'
  | from /opt/topological_inventory-sync/lib/topological_inventory/sync/sources_sync_worker.rb:3:in `<top (required)>'
  | from /opt/topological_inventory-sync/lib/topological_inventory/sync.rb:2:in `require'
  | from /opt/topological_inventory-sync/lib/topological_inventory/sync.rb:2:in `<top (required)>'
  | from bin/topological-inventory-sources-sync:9:in `require'
  | from bin/topological-inventory-sources-sync:9:in `<main>'
```