### PR TITLE
Improve error logging when hitting sources-api

### DIFF
--- a/lib/topological_inventory/sync/inventory_upload/payload.rb
+++ b/lib/topological_inventory/sync/inventory_upload/payload.rb
@@ -85,9 +85,10 @@ module TopologicalInventory
         end
 
         def create_source(sources_api, source_uid, source_name, source_type)
-          logger.info("Creating source")
+          logger.info("Creating Source")
           new_source = SourcesApiClient::Source.new(:uid => source_uid, :name => source_name, :source_type_id => source_type.id)
           source, = sources_api.create_source_with_http_info(new_source)
+          logger.info("Created Source: Name [#{source_name}] UID [#{source_uid}] Type [#{source_type.name}]")
           source
         rescue SourcesApiClient::ApiError => e
           raise "Failed to create source [#{source_name}] [#{source_uid}] [#{source_type.name}]: #{e.response_body}"

--- a/lib/topological_inventory/sync/inventory_upload/payload.rb
+++ b/lib/topological_inventory/sync/inventory_upload/payload.rb
@@ -66,35 +66,31 @@ module TopologicalInventory
 
         def find_or_create_source(source_type_name, source_name, source_uid)
           sources_api = sources_api_client(account)
-          source_type = find_source_type(source_type_name, sources_api)
+          source_type = find_source_type(sources_api, source_type_name)
+          raise "Failed to find source type [#{source_type_name}]" if source_type.nil?
 
-          sources = sources_api.list_sources({:filter => {:uid => source_uid}})
-          if sources.data.blank?
-            source = SourcesApiClient::Source.new(:uid => source_uid, :name => source_name, :source_type_id => source_type.id)
-            source, status_code, _ = sources_api.create_source_with_http_info(source)
-
-            if status_code == 201
-              logger.info("Source #{source_name}(#{source_uid}) created successfully")
-              source
-            else
-              raise "Failed to create Source #{source_name} (#{source_uid})"
-            end
-          else
-            logger.debug("Source #{source_name} (#{source_uid}) found")
-            sources.data.first
-          end
+          find_source(sources_api, source_uid) || create_source(sources_api, source_uid, source_name, source_type)
         end
 
-        def find_source_type(source_type_name, sources_api)
-          raise 'Missing Source Type name!' if source_type_name.blank?
+        def find_source_type(sources_api, source_type_name)
+          sources_api.list_source_types({:filter => {:name => source_type_name}})&.data&.first
+        rescue SourcesApiClient::ApiError => e
+          raise "Failed to find source type [#{source_type_name}]: #{e.response_body}"
+        end
 
-          response = sources_api.list_source_types({:filter => {:name => source_type_name}})
-          if response.data.blank?
-            raise "Source Type #{source_type_name} not found!"
-          else
-            logger.info("Source Type #{source_type_name} found")
-            response.data.first
-          end
+        def find_source(sources_api, source_uid)
+          sources_api.list_sources({:filter => {:uid => source_uid}})&.data&.first
+        rescue SourcesApiClient::ApiError => e
+          raise "Failed to find source [#{source_uid}]: #{e.response_body}"
+        end
+
+        def create_source(sources_api, source_uid, source_name, source_type)
+          logger.info("Creating source")
+          new_source = SourcesApiClient::Source.new(:uid => source_uid, :name => source_name, :source_type_id => source_type.id)
+          source, = sources_api.create_source_with_http_info(new_source)
+          source
+        rescue SourcesApiClient::ApiError => e
+          raise "Failed to create source [#{source_name}] [#{source_uid}] [#{source_type.name}]: #{e.response_body}"
         end
 
         def send_to_ingress_api(inventory)

--- a/lib/topological_inventory/sync/inventory_upload/payload/cfme.rb
+++ b/lib/topological_inventory/sync/inventory_upload/payload/cfme.rb
@@ -6,8 +6,7 @@ module TopologicalInventory
           def process
             cfme_ems_types.each do |ems_type|
               payload[ems_type].to_a.each do |provider_payload|
-                inventory = provider_inventory(ems_type, provider_payload)
-                send_to_ingress_api(inventory)
+                provider_inventory(ems_type, provider_payload)
               end
             end
           end
@@ -19,7 +18,10 @@ module TopologicalInventory
             source_uid  = provider_payload["guid"]
             source_name = provider_payload["name"]
 
-            find_or_create_source(source_type, source_name, source_uid)
+            logger.info("Processing CFME Provider [#{source_uid}] [#{source_name}]...")
+
+            source = find_or_create_source(source_type, source_name, source_uid)
+            logger.info("Source ID [#{source.id}] Name [#{source.name}] Type [#{source_type}]")
 
             inventory = TopologicalInventoryIngressApiClient::Inventory.new(
               :source                  => source_uid,
@@ -154,7 +156,9 @@ module TopologicalInventory
               inventory.collections << vms_collection
             end
 
-            inventory
+            send_to_ingress_api(inventory)
+
+            logger.info("Processing CFME provider [#{source_uid}] [#{source_name}]...Complete")
           end
 
           def ems_type_to_source_type

--- a/spec/topological_inventory/sync/inventory_upload/payload/cfme_spec.rb
+++ b/spec/topological_inventory/sync/inventory_upload/payload/cfme_spec.rb
@@ -5,10 +5,11 @@ RSpec.describe TopologicalInventory::Sync::InventoryUpload::Payload::Cfme do
   include InventoryUploadHelper
 
   context "#process" do
+    let(:source) { SourcesApiClient::Source.new }
     it "parses cfme inventory and sends to ingress-api" do
       payload = described_class.new(cfme_inventory, "12345")
 
-      expect(payload).to receive(:find_or_create_source)
+      expect(payload).to receive(:find_or_create_source).and_return(source)
       expect(payload).to receive(:send_to_ingress_api)
 
       payload.process


### PR DESCRIPTION
When the source-api-client is handling an unsuccessful API call it
doesn't return the error code but instead raises an exception.  This was
making it extremely difficult to figure out why something was failing
because all we got was "400 Bad Request" (the Exception Class) not _why_
it was a bad request (duplicate source_name).