### PR TITLE
Require topological_inventory core logging

### DIFF
--- a/bin/topological-inventory-sources-sync
+++ b/bin/topological-inventory-sources-sync
@@ -30,6 +30,8 @@ require "sources-api-client"
 SourcesApiClient.configure do |config|
   config.scheme = ENV["SOURCES_SCHEME"] || "http"
   config.host   = "#{ENV["SOURCES_HOST"]}:#{ENV["SOURCES_PORT"]}"
+
+  require "topological_inventory/core/logging"
   config.logger = TopologicalInventory::Core.logger
 end
 


### PR DESCRIPTION
Fix an undefined method logging caused by not requiring the module.

https://github.com/ManageIQ/topological_inventory-core/pull/147 started exposing this