### PR TITLE
Set Hardware#memory_by to 0 when value is missing in Parser:Cfme

### DIFF
--- a/lib/topological_inventory/sync/inventory_upload/parser/cfme.rb
+++ b/lib/topological_inventory/sync/inventory_upload/parser/cfme.rb
@@ -49,7 +49,7 @@ module TopologicalInventory
           end
 
           def parse_host(host_data)
-            memory_mb = host_data.dig("hardware", "memory_mb")
+            memory_mb = host_data.dig("hardware", "memory_mb") || 0
             cluster_ref = host_data.dig("ems_cluster", "ems_ref")
             cluster     = ingress_api_lazy_ref("clusters", cluster_ref) unless cluster_ref.nil?
 

--- a/spec/topological_inventory/sync/inventory_upload/parser/cfme_spec.rb
+++ b/spec/topological_inventory/sync/inventory_upload/parser/cfme_spec.rb
@@ -1,0 +1,9 @@
+require "topological_inventory/sync/inventory_upload/parser"
+require 'topological_inventory-ingress_api-client'
+
+RSpec.describe TopologicalInventory::Sync::InventoryUpload::Parser::Cfme do
+  it "parses missing Host#memory as zero" do
+    expect(TopologicalInventoryIngressApiClient::Host).to receive(:new).with(hash_including(:memory => 0))
+    described_class.new('XXX', 'XXX', 'XXX', {}).send(:parse_host, {})
+  end
+end


### PR DESCRIPTION

I saw `nils` in  `Hardware#memory_by`  in testing DB - so when the nil would be propagated here it will throw error because there is `*` operation.


@miq-bot assign @agrare 