### PR TITLE
Use cache_with_timeout for application_types

### DIFF
--- a/lib/topological_inventory/sync/worker.rb
+++ b/lib/topological_inventory/sync/worker.rb
@@ -78,18 +78,26 @@ module TopologicalInventory
         }
       end
 
-      def sources_api_client(tenant = nil)
+      def self.sources_api_client(tenant = nil)
         api_client = SourcesApiClient::ApiClient.new
         api_client.default_headers.merge!(identity_headers(tenant)) if tenant
         SourcesApiClient::DefaultApi.new(api_client)
       end
 
-      def identity_headers(tenant)
+      def sources_api_client(tenant = nil)
+        self.class.sources_api_client(tenant)
+      end
+
+      def self.identity_headers(tenant)
         {
           "x-rh-identity" => Base64.strict_encode64(
             JSON.dump({"identity" => {"account_number" => tenant}})
           )
         }
+      end
+
+      def identity_headers(tenant)
+        self.class.identity_headers(tenant)
       end
     end
   end

--- a/spec/topological_inventory/sync/sources_sync_worker_spec.rb
+++ b/spec/topological_inventory/sync/sources_sync_worker_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe TopologicalInventory::Sync::SourcesSyncWorker do
       )
     )
     allow(sources_api_client).to receive(:show_source).and_return(SourcesApiClient::Source.new(source))
-    allow(sources_sync).to receive(:sources_api_client).and_return(sources_api_client)
+    allow(described_class).to    receive(:sources_api_client).and_return(sources_api_client)
   end
 
   context "#initial_sync" do


### PR DESCRIPTION
Use cache_with_timeout for supported application types so that any
updates while the sources-sync worker is running will be picked up
within 5 minutes