### PR TITLE
The RHV source_type.name is ovirt not rhv

### DIFF
--- a/lib/topological_inventory/sync/inventory_upload/payload/cfme.rb
+++ b/lib/topological_inventory/sync/inventory_upload/payload/cfme.rb
@@ -32,7 +32,7 @@ module TopologicalInventory
           def ems_type_to_source_type
             @ems_type_to_source_type ||= {
               "ManageIQ::Providers::OpenStack::CloudManager" => "openstack",
-              "ManageIQ::Providers::Redhat::InfraManager"    => "rhv",
+              "ManageIQ::Providers::Redhat::InfraManager"    => "ovirt",
               "ManageIQ::Providers::Vmware::InfraManager"    => "vsphere"
             }.freeze
           end


### PR DESCRIPTION
Fix an issue with uploading ManageIQ::Providers::Redhat::InfraManager
sources from cloudforms.

https://github.com/ManageIQ/sources-api/blob/master/db/seeds/source_types.rb#L75