### PR TITLE
Fix typo, Openstack not OpenStack

### DIFF
--- a/lib/topological_inventory/sync/inventory_upload/payload/cfme.rb
+++ b/lib/topological_inventory/sync/inventory_upload/payload/cfme.rb
@@ -31,7 +31,7 @@ module TopologicalInventory
 
           def ems_type_to_source_type
             @ems_type_to_source_type ||= {
-              "ManageIQ::Providers::OpenStack::CloudManager" => "openstack",
+              "ManageIQ::Providers::Openstack::CloudManager" => "openstack",
               "ManageIQ::Providers::Redhat::InfraManager"    => "ovirt",
               "ManageIQ::Providers::Vmware::InfraManager"    => "vsphere"
             }.freeze


### PR DESCRIPTION
The payload parser was looking for OpenStack not Openstack.

Depends on: https://github.com/ManageIQ/topological_inventory-sync/pull/44