### PR TITLE
Get datastore ems_ref from host_storage or storage

### DIFF
--- a/lib/topological_inventory/sync/inventory_upload/parser/cfme.rb
+++ b/lib/topological_inventory/sync/inventory_upload/parser/cfme.rb
@@ -96,7 +96,7 @@ module TopologicalInventory
                 )
 
                 host_storages.each do |host_storage|
-                  host_ref = host_storage.dig("host", "ems_ref")
+                  host_ref = host_storage.dig("host", "ems_ref") || storage_data["ems_ref"]
                   next if host_ref.nil?
 
                   datastore_mounts_collection.data << TopologicalInventoryIngressApiClient::DatastoreMount.new(


### PR DESCRIPTION
RHV doesn't set host_storage.ems_ref like vmware so we have to get it
from host_storage.ems_ref || storage.ems_ref

Depends on: https://github.com/ManageIQ/topological_inventory-api/pull/242