### PR TITLE
Host sync worker: only send RHEL hosts to HBI, passing marketplace flag

### DIFF
--- a/lib/topological_inventory/sync/host_inventory_sync_worker.rb
+++ b/lib/topological_inventory/sync/host_inventory_sync_worker.rb
@@ -115,6 +115,7 @@ module TopologicalInventory
         topological_inventory_vms.each do |host|
           # Skip processing if we've already created this host in Host Based
           next if !host["host_inventory_uuid"].nil? && !host["host_inventory_uuid"].empty?
+          next unless is_rhel?(host)
 
           data = {
             :display_name    => host["name"],
@@ -122,7 +123,8 @@ module TopologicalInventory
             :mac_addresses   => host["mac_addresses"],
             :account         => account_number,
             :reporter        => HOST_INVENTORY_REPORTER,
-            :stale_timestamp => stale_timestamp
+            :stale_timestamp => stale_timestamp,
+            :system_profile  => { :is_marketplace => is_marketplace?(host) }
           }
 
           # TODO(lsmola) use the possibility to create batch of VMs in Host Inventory
@@ -131,6 +133,15 @@ module TopologicalInventory
       rescue => e
         logger.error("#{e.message} -  #{e.backtrace.join("\n")}")
         metrics&.record_error(:request)
+      end
+
+      def is_rhel?(host)
+        host["guest_info"] == "Red Hat BYOL Linux" ||
+        host["guest_info"] == "Red Hat Enterprise Linux"
+      end
+
+      def is_marketplace?(host)
+        host["guest_info"] != "Red Hat BYOL Linux"
       end
 
       def create_host_inventory_hosts(data, source)

--- a/lib/topological_inventory/sync/host_inventory_sync_worker.rb
+++ b/lib/topological_inventory/sync/host_inventory_sync_worker.rb
@@ -115,7 +115,7 @@ module TopologicalInventory
         topological_inventory_vms.each do |host|
           # Skip processing if we've already created this host in Host Based
           next if !host["host_inventory_uuid"].nil? && !host["host_inventory_uuid"].empty?
-          next unless is_rhel?(host)
+          next unless rhel?(host)
 
           data = {
             :display_name    => host["name"],
@@ -124,7 +124,7 @@ module TopologicalInventory
             :account         => account_number,
             :reporter        => HOST_INVENTORY_REPORTER,
             :stale_timestamp => stale_timestamp,
-            :system_profile  => { :is_marketplace => is_marketplace?(host) }
+            :system_profile  => {:is_marketplace => marketplace?(host)}
           }
 
           # TODO(lsmola) use the possibility to create batch of VMs in Host Inventory
@@ -135,12 +135,12 @@ module TopologicalInventory
         metrics&.record_error(:request)
       end
 
-      def is_rhel?(host)
+      def rhel?(host)
         host["guest_info"] == "Red Hat BYOL Linux" ||
-        host["guest_info"] == "Red Hat Enterprise Linux"
+          host["guest_info"] == "Red Hat Enterprise Linux"
       end
 
-      def is_marketplace?(host)
+      def marketplace?(host)
         host["guest_info"] != "Red Hat BYOL Linux"
       end
 

--- a/spec/topological_inventory/sync/host_inventory_sync_worker_spec.rb
+++ b/spec/topological_inventory/sync/host_inventory_sync_worker_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe TopologicalInventory::Sync::HostInventorySyncWorker do
         :display_name    => nil,
         :reporter        => "topological-inventory",
         :stale_timestamp => (Time.now.utc + 86_400).to_datetime,
-        :system_profile  => { :is_marketplace => true }
+        :system_profile  => {:is_marketplace => true}
       },
       source
     ]

--- a/spec/topological_inventory/sync/host_inventory_sync_worker_spec.rb
+++ b/spec/topological_inventory/sync/host_inventory_sync_worker_spec.rb
@@ -111,11 +111,11 @@ RSpec.describe TopologicalInventory::Sync::HostInventorySyncWorker do
           .with([1, 2, 3, 4, 5], "eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImV4dGVybmFsX3RlbmFu\ndF91dWlkIn19\n")
           .and_return(
             [
-              {"id" => "1", "source_ref" => "vm1", "mac_addresses" => mac_addresses_1},
-              {"id" => "2", "source_ref" => "vm2", "mac_addresses" => mac_addresses_2, "host_inventory_uuid" => ""},
-              {"id" => "3", "source_ref" => "vm3", "mac_addresses" => mac_addresses_3, "host_inventory_uuid" => nil},
-              {"id" => "4", "source_ref" => "vm4", "mac_addresses" => []},
-              {"id" => "5", "source_ref" => "vm5", "mac_addresses" => mac_addresses_5, "host_inventory_uuid" => "host_uuid_5"},
+              {"id" => "1", "source_ref" => "vm1", "mac_addresses" => mac_addresses_1, "guest_info" => "Red Hat Enterprise Linux"},
+              {"id" => "2", "source_ref" => "vm2", "mac_addresses" => mac_addresses_2, "host_inventory_uuid" => "", "guest_info" => "Red Hat Enterprise Linux"},
+              {"id" => "3", "source_ref" => "vm3", "mac_addresses" => mac_addresses_3, "host_inventory_uuid" => nil, "guest_info" => "Red Hat Enterprise Linux"},
+              {"id" => "4", "source_ref" => "vm4", "mac_addresses" => [], "guest_info" => "Red Hat Enterprise Linux"},
+              {"id" => "5", "source_ref" => "vm5", "mac_addresses" => mac_addresses_5, "host_inventory_uuid" => "host_uuid_5", "guest_info" => "Red Hat Enterprise Linux"},
             ]
           )
       )
@@ -189,7 +189,8 @@ RSpec.describe TopologicalInventory::Sync::HostInventorySyncWorker do
         :external_id     => source_ref,
         :display_name    => nil,
         :reporter        => "topological-inventory",
-        :stale_timestamp => (Time.now.utc + 86_400).to_datetime
+        :stale_timestamp => (Time.now.utc + 86_400).to_datetime,
+        :system_profile  => { :is_marketplace => true }
       },
       source
     ]


### PR DESCRIPTION
Using the "guest_info" metadata, determine if the host in question is RHEL based, and if so, is it marketplace licensed. Only sync RHEL based hosts to HBI passing the new marketplace status boolean.