### PR TITLE
Filter hosts that don't have a MAC address.

### DIFF
--- a/lib/topological_inventory/sync/host_inventory_sync_worker.rb
+++ b/lib/topological_inventory/sync/host_inventory_sync_worker.rb
@@ -115,7 +115,10 @@ module TopologicalInventory
         topological_inventory_vms.each do |host|
           # Skip processing if we've already created this host in Host Based
           next if !host["host_inventory_uuid"].nil? && !host["host_inventory_uuid"].empty?
+          # Only send RHEL hosts to HBI
           next unless rhel?(host)
+          # HBI requires MAC address, so hosts without MAC address are not sent
+          next if host["mac_addresses"].to_a.empty?
 
           data = {
             :display_name    => host["name"],

--- a/spec/topological_inventory/sync/host_inventory_sync_worker_spec.rb
+++ b/spec/topological_inventory/sync/host_inventory_sync_worker_spec.rb
@@ -135,7 +135,8 @@ RSpec.describe TopologicalInventory::Sync::HostInventorySyncWorker do
           .with(*make_host_arg(mac_addresses_3, "vm3"))
       )
 
-      expect(host_inventory_sync_service).to(
+      # HBI requires MAC address, so hosts without MAC address are not sent.
+      expect(host_inventory_sync_service).to_not(
         receive(:create_host_inventory_hosts)
           .with(*make_host_arg([], "vm4"))
       )


### PR DESCRIPTION
HBI does not accept hosts that don't have a MAC address, so don't send those hosts to HBI.