### PR TITLE
Fix of docker image build (mimemagic)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN dnf -y --disableplugin=subscription-manager module enable ruby:2.6 && \
       git make redhat-rpm-config \
       # For checking service status
       nmap-ncat \
+      # For the mimemagic gem
+      shared-mime-info \
       # Libraries
       postgresql-devel libxml2-devel \
       && \

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "rest-client",      ">= 1.8.0"
 
 gem "sources-api-client", "~> 1.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0", ">= 1.0.1"
-gem "topological_inventory-core", "~> 1.1.1"
+gem "topological_inventory-core", "~> 1.2.1"
 gem "topological_inventory-api-client", "~> 2.0"
 gem "topological_inventory-providers-common", "~> 0.1"
 


### PR DESCRIPTION
I wan't able to build docker image with core 1.1.x because of error in mimemagic. It looks like newer rails version is needed. 

```
...
Could not find MIME type database in the following locations:
["/usr/local/share/mime/packages/freedesktop.org.xml",
"/opt/homebrew/share/mime/packages/freedesktop.org.xml",
"/opt/local/share/mime/packages/freedesktop.org.xml",
"/usr/share/mime/packages/freedesktop.org.xml"]
...
In Gemfile:
  topological_inventory-core was resolved to 1.1.8, which depends on
    acts_as_tenant was resolved to 0.4.4, which depends on
      rails was resolved to 5.2.4.5, which depends on
        activestorage was resolved to 5.2.4.5, which depends on
          marcel was resolved to 0.3.3, which depends on
            mimemagic
...
```

---

https://github.com/RedHatInsights/topological_inventory-api/issues/353

[RHCLOUD-13462](https://issues.redhat.com/browse/RHCLOUD-13462)